### PR TITLE
Update fastjson version from 1.2.67 to 2.0.60

### DIFF
--- a/vlife-boot-starter-web/pom.xml
+++ b/vlife-boot-starter-web/pom.xml
@@ -44,7 +44,7 @@
         <dependency>
             <groupId>com.alibaba</groupId>
             <artifactId>fastjson</artifactId>
-            <version>1.2.67</version>
+            <version>2.0.60</version>
         </dependency>
         <dependency>
             <groupId>org.apache.commons</groupId>


### PR DESCRIPTION
Consider updating fastjson version to 2.0.60 to prevent a number of high severity vulnerabilites.

Vulnerability details have been shared with maintainers over email.